### PR TITLE
Consolidate Hash State

### DIFF
--- a/test/component-tests/hashMapI.js
+++ b/test/component-tests/hashMapI.js
@@ -51,9 +51,7 @@ contract('HashMapI', async (accounts) => {
         // Get the hashMap details of first index, next index and count of active entries
         const info = await hashMapITest.hashMap();
         // Check if first, next and count are correct
-        expect(firstIdx).to.be.eql(info[0].valueOf());
-        expect(nextIdx).to.be.eql(info[1].valueOf());
-        expect(count).to.be.eql(info[2].valueOf());
+        expect([firstIdx, nextIdx, count]).to.be.eql(info.map(x => x.valueOf()));
 
         // Verify the first 10 entries in the hash map
         for (let i=1; i<=10; i++)


### PR DESCRIPTION

#### Changes
This consolidates hashState from hashActive and hashArchive.
This will save gas by reducing the number of sstore, sload, and sha3 functions required.
Reviewers @martinstellnberger